### PR TITLE
select all button, change to schedule course loading methodology

### DIFF
--- a/frontend/src/features/courses/components/SectionOptionList.tsx
+++ b/frontend/src/features/courses/components/SectionOptionList.tsx
@@ -1,0 +1,161 @@
+import * as React from "react";
+import { Zap, ZapOff } from "lucide-react";
+import { hasScheduleConflict } from "@/lib/schedule/schedule";
+import type { Meeting } from "@/types/schedule";
+import { cn } from "@/lib/utils";
+import { SectionOptionCard } from "./SectionOptionCard";
+
+export type SectionOption = {
+  key: string;
+  type: string;
+  section: string;
+  crn: string;
+  meetings: Meeting[];
+  instructor: string;
+  seatsAvailable: number;
+  enrolled: number;
+  maxEnroll: number;
+};
+
+export function groupMeetingOptions(meetings: Meeting[]): SectionOption[] {
+  const options: SectionOption[] = [];
+
+  for (const meeting of meetings) {
+    const key = `${meeting.type}::${meeting.section}::${meeting.crn}`;
+    const existing = options.find((option) => option.key === key);
+
+    if (existing) {
+      existing.meetings.push(meeting);
+      if (!existing.instructor && meeting.instructor) existing.instructor = meeting.instructor;
+      continue;
+    }
+
+    options.push({
+      key,
+      type: meeting.type,
+      section: meeting.section,
+      crn: meeting.crn,
+      meetings: [meeting],
+      instructor: meeting.instructor,
+      seatsAvailable: meeting.seatsAvailable,
+      enrolled: meeting.enrolled,
+      maxEnroll: meeting.maxEnroll,
+    });
+  }
+
+  return [...options].sort((a, b) =>
+    a.key.localeCompare(b.key, undefined, { numeric: true, sensitivity: "base" }),
+  );
+}
+
+export function getMeetingKey(meeting: Meeting) {
+  return `${meeting.type}::${meeting.section}::${meeting.crn}::${meeting.start}::${meeting.end}`;
+}
+
+export function getSelectedOptionKey(meetings: Meeting[]) {
+  const first = meetings[0];
+  if (!first) return null;
+  return `${first.type}::${first.section}::${first.crn}`;
+}
+
+export function isMultiSectionSelected(meetings: Meeting[]) {
+  return new Set(meetings.map((m) => `${m.type}::${m.section}::${m.crn}`)).size > 1;
+}
+
+interface SectionOptionListProps {
+  options: SectionOption[];
+  selectedMeetings: Meeting[];
+  otherMeetings: Meeting[];
+  onApplyOption: (option: SectionOption) => void;
+  onApplyAllNonConflicting: (nonConflictingOptions: SectionOption[], isAllSelected: boolean) => void;
+}
+
+export function SectionOptionList({
+  options,
+  selectedMeetings,
+  otherMeetings,
+  onApplyOption,
+  onApplyAllNonConflicting,
+}: SectionOptionListProps) {
+  const nonConflictingOptions = React.useMemo(
+    () => options.filter((opt) => !opt.meetings.some((m) => hasScheduleConflict(otherMeetings, m))),
+    [options, otherMeetings],
+  );
+
+  const selectedMeetingKeys = React.useMemo(
+    () => new Set(selectedMeetings.map(getMeetingKey)),
+    [selectedMeetings],
+  );
+
+  const allNonConflictingKeys = React.useMemo(
+    () => new Set(nonConflictingOptions.flatMap((opt) => opt.meetings.map(getMeetingKey))),
+    [nonConflictingOptions],
+  );
+
+  const isAllSelected =
+    allNonConflictingKeys.size > 0 &&
+    allNonConflictingKeys.size === selectedMeetingKeys.size &&
+    Array.from(allNonConflictingKeys).every((k) => selectedMeetingKeys.has(k));
+
+  const isMulti = isMultiSectionSelected(selectedMeetings);
+  const singleSelectedKey = isMulti ? null : getSelectedOptionKey(selectedMeetings);
+
+  return (
+    <>
+      {nonConflictingOptions.length > 0 && (
+        <div className="mb-3 flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            {nonConflictingOptions.length} section{nonConflictingOptions.length === 1 ? "" : "s"} available
+          </p>
+          <button
+            type="button"
+            onClick={() => onApplyAllNonConflicting(nonConflictingOptions, isAllSelected)}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors",
+              isAllSelected
+                ? "border-sky-300 bg-sky-100 text-sky-700 hover:bg-sky-200 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-200 dark:hover:bg-sky-900/60"
+                : "border-slate-200 bg-white text-slate-600 hover:border-[#d8c3aa] hover:bg-[#fbf7f1] dark:border-[#3a3a3a] dark:bg-[#2a2a2a] dark:text-slate-300 dark:hover:border-[#6d4f36] dark:hover:bg-[#2a221d]",
+            )}
+          >
+            {isAllSelected ? (
+              <>
+                <ZapOff className="h-3.5 w-3.5" />
+                Deselect all
+              </>
+            ) : (
+              <>
+                <Zap className="h-3.5 w-3.5" />
+                Select all available
+              </>
+            )}
+          </button>
+        </div>
+      )}
+      <div className="space-y-3">
+        {options.map((option) => {
+          const isSelected = isAllSelected
+            ? nonConflictingOptions.some((o) => o.key === option.key)
+            : singleSelectedKey === option.key;
+          const conflictingMeetings = option.meetings.filter((m) => hasScheduleConflict(otherMeetings, m));
+
+          return (
+            <SectionOptionCard
+              key={option.key}
+              onClick={() => onApplyOption(option)}
+              sectionLabel={`${option.type} ${option.section}`}
+              instructor={option.instructor}
+              crn={option.crn}
+              seatsAvailable={option.seatsAvailable}
+              enrolled={option.enrolled}
+              maxEnroll={option.maxEnroll}
+              meetings={option.meetings}
+              isSelected={isSelected}
+              hasConflict={conflictingMeetings.length > 0}
+              conflictingMeetingKeys={conflictingMeetings.map(getMeetingKey)}
+            />
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/features/courses/components/SubjectCourseList.tsx
+++ b/frontend/src/features/courses/components/SubjectCourseList.tsx
@@ -6,78 +6,19 @@ import {
 } from "lucide-react";
 import { useSchedule } from "@/context/schedule/schedule-context";
 import type { Course, Meeting } from "@/types/schedule";
-import { hasScheduleConflict } from "@/lib/schedule/schedule";
 import { cn } from "@/lib/utils";
-import { SectionOptionCard } from "./SectionOptionCard";
-
-type SectionOption = {
-  key: string;
-  type: string;
-  section: string;
-  crn: string;
-  meetings: Meeting[];
-  instructor: string;
-  seatsAvailable: number;
-  enrolled: number;
-  maxEnroll: number;
-};
-
-function groupMeetingOptions(meetings: Meeting[]) {
-  const options: SectionOption[] = [];
-
-  for (const meeting of meetings) {
-    const optionKey = `${meeting.type}::${meeting.section}::${meeting.crn}`;
-    const existing = options.find((option) => option.key === optionKey);
-
-    if (existing) {
-      existing.meetings.push(meeting);
-      if (!existing.instructor && meeting.instructor) existing.instructor = meeting.instructor;
-      continue;
-    }
-
-    options.push({
-      key: optionKey,
-      type: meeting.type,
-      section: meeting.section,
-      crn: meeting.crn,
-      meetings: [meeting],
-      instructor: meeting.instructor,
-      seatsAvailable: meeting.seatsAvailable,
-      enrolled: meeting.enrolled,
-      maxEnroll: meeting.maxEnroll,
-    });
-  }
-
-  return [...options].sort((a, b) =>
-    a.key.localeCompare(b.key, undefined, { numeric: true, sensitivity: "base" }),
-  );
-}
-
-function buildDefaultSelection(course: Course, override?: SectionOption): Meeting[] {
-  const options = groupMeetingOptions(course.meetings);
-  const option = override ?? options[0];
-  return option?.meetings ?? [];
-}
-
-function getSelectedOptionKey(meetings: Meeting[]) {
-  const selectedMeeting = meetings[0];
-  if (!selectedMeeting) return null;
-  return `${selectedMeeting.type}::${selectedMeeting.section}::${selectedMeeting.crn}`;
-}
-
-function getMeetingKey(meeting: Meeting) {
-  return `${meeting.type}::${meeting.section}::${meeting.crn}::${meeting.start}::${meeting.end}`;
-}
+import {
+  groupMeetingOptions,
+  getSelectedOptionKey,
+  isMultiSectionSelected,
+  SectionOptionList,
+} from "./SectionOptionList";
+import type { SectionOption } from "./SectionOptionList";
 
 function getOtherCourseMeetings(courses: Course[], courseId: string) {
   return courses
     .filter((course) => course.id !== courseId)
     .flatMap((course) => course.meetings);
-}
-
-function hasOptionConflict(otherMeetings: Meeting[], option: SectionOption, currentCourse: Course | undefined) {
-  const meetingsToCheck = currentCourse && getSelectedOptionKey(currentCourse.meetings) === option.key ? otherMeetings : otherMeetings;
-  return option.meetings.some((meeting) => hasScheduleConflict(meetingsToCheck, meeting));
 }
 
 interface SubjectCourseListProps {
@@ -119,18 +60,27 @@ export function SubjectCourseList({
   const applyOption = React.useCallback(
     (course: Course, option: SectionOption) => {
       const selectedCourse = selectedCourseMap.get(course.id);
-      const isSameOptionSelected = selectedCourse && getSelectedOptionKey(selectedCourse.meetings) === option.key;
-      const nextMeetings = selectedCourse
-        ? isSameOptionSelected
-          ? []
-          : option.meetings
-        : buildDefaultSelection(course, option);
+      const isMulti = selectedCourse ? isMultiSectionSelected(selectedCourse.meetings) : false;
+      const isSameOptionSelected =
+        selectedCourse && !isMulti && getSelectedOptionKey(selectedCourse.meetings) === option.key;
 
       if (selectedCourse) removeCourse(course.id);
-      if (nextMeetings.length > 0) addCourse({ ...course, meetings: nextMeetings });
+      if (!isSameOptionSelected) addCourse({ ...course, meetings: option.meetings });
       setOpenCards((prev) => ({ ...prev, [course.id]: true }));
     },
     [addCourse, removeCourse, selectedCourseMap],
+  );
+
+  const applyAllNonConflicting = React.useCallback(
+    (course: Course, nonConflictingOptions: SectionOption[], isAllSelected: boolean) => {
+      removeCourse(course.id);
+      if (!isAllSelected) {
+        const allMeetings = nonConflictingOptions.flatMap((opt) => opt.meetings);
+        if (allMeetings.length > 0) addCourse({ ...course, meetings: allMeetings });
+      }
+      setOpenCards((prev) => ({ ...prev, [course.id]: true }));
+    },
+    [addCourse, removeCourse],
   );
 
   if (courses.length === 0) {
@@ -154,10 +104,13 @@ export function SubjectCourseList({
         const options = groupMeetingOptions(course.meetings);
         const sectionCount = options.length;
         const selectedLabels = (() => {
-          const key = getSelectedOptionKey(selectedCourse?.meetings ?? []);
+          if (!selectedCourse) return [];
+          if (isMultiSectionSelected(selectedCourse.meetings)) return ["All available"];
+          const key = getSelectedOptionKey(selectedCourse.meetings);
           const option = options.find((entry) => entry.key === key);
           return option ? [`${option.type} ${option.section}`] : [];
         })();
+        const otherMeetings = otherMeetingsByCourse.get(course.id) ?? [];
 
         return (
           <article
@@ -224,32 +177,15 @@ export function SubjectCourseList({
                   showCourseHeader && "bg-slate-50/60 px-5 py-4 dark:bg-[#1a1a1a]",
                 )}
               >
-                <div className="space-y-3">
-                  {options.map((option) => {
-                    const selectedKey = getSelectedOptionKey(selectedCourse?.meetings ?? []);
-                    const otherMeetings = otherMeetingsByCourse.get(course.id) ?? [];
-                    const isSelected = selectedKey === option.key;
-                    const conflictingMeetings = option.meetings.filter((meeting) => hasScheduleConflict(otherMeetings, meeting));
-                    const hasConflict = conflictingMeetings.length > 0;
-
-                    return (
-                      <SectionOptionCard
-                        key={option.key}
-                        onClick={() => applyOption(course, option)}
-                        sectionLabel={`Section ${option.section}`}
-                        instructor={option.instructor}
-                        crn={option.crn}
-                        seatsAvailable={option.seatsAvailable}
-                        enrolled={option.enrolled}
-                        maxEnroll={option.maxEnroll}
-                        meetings={option.meetings}
-                        isSelected={isSelected}
-                        hasConflict={hasConflict}
-                        conflictingMeetingKeys={conflictingMeetings.map(getMeetingKey)}
-                      />
-                    );
-                  })}
-                </div>
+                <SectionOptionList
+                  options={options}
+                  selectedMeetings={selectedCourse?.meetings ?? []}
+                  otherMeetings={otherMeetings}
+                  onApplyOption={(option) => applyOption(course, option)}
+                  onApplyAllNonConflicting={(nonConflicting, isAllSelected) =>
+                    applyAllNonConflicting(course, nonConflicting, isAllSelected)
+                  }
+                />
               </div>
             ) : null}
           </article>

--- a/frontend/src/features/schedule/components/ScheduleList.tsx
+++ b/frontend/src/features/schedule/components/ScheduleList.tsx
@@ -4,66 +4,16 @@ import { CalendarDays, ChevronDown, ChevronUp, Download, Trash2 } from "lucide-r
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useSchedule } from "@/context/schedule/schedule-context";
-import { SectionOptionCard } from "@/features/courses/components/SectionOptionCard";
+import { fetchCoursesByDepartment } from "@/api";
+import {
+  groupMeetingOptions,
+  getSelectedOptionKey,
+  isMultiSectionSelected,
+  SectionOptionList,
+} from "@/features/courses/components/SectionOptionList";
+import type { SectionOption } from "@/features/courses/components/SectionOptionList";
 import { buildScheduleIcs, hasExportableMeetings } from "@/lib/schedule/calendarExport";
-import { hasScheduleConflict } from "@/lib/schedule/schedule";
 import type { Course, Meeting } from "@/types/schedule";
-
-type MeetingOption = {
-  key: string;
-  type: string;
-  section: string;
-  crn: string;
-  meetings: Meeting[];
-  instructor: string;
-  seatsAvailable: number;
-  enrolled: number;
-  maxEnroll: number;
-};
-
-function groupMeetingOptions(meetings: Meeting[]) {
-  const options: MeetingOption[] = [];
-
-  for (const meeting of meetings) {
-    const key = `${meeting.type}::${meeting.section}::${meeting.crn}`;
-    const existing = options.find((option) => option.key === key);
-
-    if (existing) {
-      existing.meetings.push(meeting);
-      if (!existing.instructor && meeting.instructor) existing.instructor = meeting.instructor;
-      continue;
-    }
-
-    options.push({
-      key,
-      type: meeting.type,
-      section: meeting.section,
-      crn: meeting.crn,
-      meetings: [meeting],
-      instructor: meeting.instructor,
-      seatsAvailable: meeting.seatsAvailable,
-      enrolled: meeting.enrolled,
-      maxEnroll: meeting.maxEnroll,
-    });
-  }
-
-  return [...options].sort((a, b) =>
-    a.key.localeCompare(b.key, undefined, {
-      numeric: true,
-      sensitivity: "base",
-    }),
-  );
-}
-
-function getSelectedOptionKey(meetings: Meeting[]) {
-  const selectedMeeting = meetings[0];
-  if (!selectedMeeting) return null;
-  return `${selectedMeeting.type}::${selectedMeeting.section}::${selectedMeeting.crn}`;
-}
-
-function getMeetingKey(meeting: Meeting) {
-  return `${meeting.type}::${meeting.section}::${meeting.crn}::${meeting.start}::${meeting.end}`;
-}
 
 interface CourseCardProps {
   course: Course;
@@ -73,6 +23,7 @@ interface CourseCardProps {
   allMeetingsForCourse: Meeting[];
   otherCourses: Course[];
   replaceCourseMeetings: (course: Course, meetings: Meeting[]) => void;
+  removeCourse: (id: string) => void;
 }
 
 function CourseCard({
@@ -83,25 +34,43 @@ function CourseCard({
   allMeetingsForCourse,
   otherCourses,
   replaceCourseMeetings,
+  removeCourse,
 }: CourseCardProps): JSX.Element {
   const allOptions = React.useMemo(() => groupMeetingOptions(allMeetingsForCourse), [allMeetingsForCourse]);
   const sectionCount = allOptions.length;
-  const selectedLabels = React.useMemo(
-    () => {
-      const selectedKey = getSelectedOptionKey(course.meetings);
-      const selectedOption = allOptions.find((option) => option.key === selectedKey);
-      return selectedOption ? [`${selectedOption.type} ${selectedOption.section}`] : [];
-    },
-    [allOptions, course.meetings],
-  );
+  const selectedLabels = React.useMemo(() => {
+    if (isMultiSectionSelected(course.meetings)) return ["All available"];
+    const selectedKey = getSelectedOptionKey(course.meetings);
+    const selectedOption = allOptions.find((option) => option.key === selectedKey);
+    return selectedOption ? [`${selectedOption.type} ${selectedOption.section}`] : [];
+  }, [allOptions, course.meetings]);
 
   const otherMeetings = React.useMemo(() => otherCourses.flatMap((otherCourse) => otherCourse.meetings), [otherCourses]);
 
   const applyOption = React.useCallback(
-    (selected: MeetingOption) => {
-      replaceCourseMeetings(course, selected.meetings);
+    (selected: SectionOption) => {
+      const isMulti = isMultiSectionSelected(course.meetings);
+      const isSameOptionSelected =
+        !isMulti && getSelectedOptionKey(course.meetings) === selected.key;
+      if (isSameOptionSelected) {
+        removeCourse(course.id);
+      } else {
+        replaceCourseMeetings(course, selected.meetings);
+      }
     },
-    [course, replaceCourseMeetings],
+    [course, replaceCourseMeetings, removeCourse],
+  );
+
+  const applyAllNonConflicting = React.useCallback(
+    (nonConflictingOptions: SectionOption[], isAllSelected: boolean) => {
+      if (isAllSelected) {
+        removeCourse(course.id);
+      } else {
+        const allMeetings = nonConflictingOptions.flatMap((opt) => opt.meetings);
+        replaceCourseMeetings(course, allMeetings);
+      }
+    },
+    [course, replaceCourseMeetings, removeCourse],
   );
 
   return (
@@ -172,30 +141,13 @@ function CourseCard({
 
       {expanded ? (
         <div className="border-t border-slate-200/70 bg-slate-50/60 px-5 py-4 dark:border-[#343434] dark:bg-[#1a1a1a]">
-          <div className="space-y-3">
-            {allOptions.map((option) => {
-              const isSelected = getSelectedOptionKey(course.meetings) === option.key;
-              const conflictingMeetings = option.meetings.filter((meeting) => hasScheduleConflict(otherMeetings, meeting));
-              const hasConflict = conflictingMeetings.length > 0;
-
-              return (
-                <SectionOptionCard
-                  key={option.key}
-                  onClick={() => applyOption(option)}
-                  sectionLabel={`${option.type} ${option.section}`}
-                  instructor={option.instructor}
-                  crn={option.crn}
-                  seatsAvailable={option.seatsAvailable}
-                  enrolled={option.enrolled}
-                  maxEnroll={option.maxEnroll}
-                  meetings={option.meetings}
-                  isSelected={isSelected}
-                  hasConflict={hasConflict}
-                  conflictingMeetingKeys={conflictingMeetings.map(getMeetingKey)}
-                />
-              );
-            })}
-          </div>
+          <SectionOptionList
+            options={allOptions}
+            selectedMeetings={course.meetings}
+            otherMeetings={otherMeetings}
+            onApplyOption={applyOption}
+            onApplyAllNonConflicting={applyAllNonConflicting}
+          />
         </div>
       ) : null}
     </article>
@@ -203,15 +155,27 @@ function CourseCard({
 }
 
 export default function ScheduleList(): JSX.Element {
-  const { courses, removeCourse, catalog, catalogStatus, loadCatalog, updateCourse } = useSchedule();
+  const { courses, removeCourse, catalog, updateCourse } = useSchedule();
   const [copiedCrn, setCopiedCrn] = React.useState<string | null>(null);
   const [exportOpen, setExportOpen] = React.useState(false);
 
+  // Fetch only the departments in the schedule instead of loading the full catalog.
+  // SchedulePage handles the full catalog load for schedule-variant cycling.
+  const [deptCourseMap, setDeptCourseMap] = React.useState<Map<string, Course>>(new Map());
   React.useEffect(() => {
-    if (courses.length > 0 && catalogStatus === "idle") {
-      void loadCatalog();
-    }
-  }, [courses.length, catalogStatus, loadCatalog]);
+    const departments = Array.from(new Set(courses.map((c) => c.department).filter(Boolean)));
+    if (departments.length === 0) return;
+    let cancelled = false;
+    Promise.all(departments.map((dept) => fetchCoursesByDepartment(dept))).then((results) => {
+      if (cancelled) return;
+      const map = new Map<string, Course>();
+      for (const deptCourses of results) {
+        for (const c of deptCourses) map.set(c.id, c);
+      }
+      setDeptCourseMap(map);
+    });
+    return () => { cancelled = true; };
+  }, [courses]);
 
   const orderRef = React.useRef<Map<string, number>>(new Map());
   React.useEffect(() => {
@@ -246,10 +210,11 @@ export default function ScheduleList(): JSX.Element {
 
   const getAllMeetingsForCourse = React.useCallback(
     (courseId: string): Meeting[] =>
+      deptCourseMap.get(courseId)?.meetings ||
       catalog.find((course) => course.id === courseId)?.meetings ||
       courses.find((course) => course.id === courseId)?.meetings ||
       [],
-    [catalog, courses],
+    [deptCourseMap, catalog, courses],
   );
 
   const selectedCrns = React.useMemo(
@@ -389,6 +354,7 @@ export default function ScheduleList(): JSX.Element {
               allMeetingsForCourse={getAllMeetingsForCourse(course.id)}
               otherCourses={displayCourses.filter((other) => other.id !== course.id)}
               replaceCourseMeetings={replaceCourseMeetings}
+              removeCourse={removeCourse}
             />
           ))}
         </div>


### PR DESCRIPTION
---
  1. Select all non-conflicting sections button
  
  Added a "Select all available" / "Deselect all" toggle button to the section picker on
  course cards. When clicked it selects every section that has no time conflict with the
  rest of your schedule and adds them all to the calendar at once. Clicking it again
  deselects (removes the course). Clicking any individual section card while in "all
  selected" mode switches back to just that one section. The course header label also
  updates to show "All available" instead of a single section name when the multi-select
  mode is active.

  ---
  2. Shared SectionOptionList component

  The section list rendering (including the new button) was extracted into a single
  shared component at features/courses/components/SectionOptionList.tsx. Both the course
  browse view (SubjectCourseList) and the schedule view (ScheduleList) now use it, so the
  behavior and UI are identical in both places. This also eliminated the duplicated
  groupMeetingOptions, getSelectedOptionKey, getMeetingKey, and SectionOption type that
  previously existed independently in each file.

  ---
  3. Fixed slow section loading on the schedule page

  On refresh, the schedule page was showing only the selected section for each course
  until all sections eventually appeared. The cause was that ScheduleList was calling
  loadCatalog() which paginates through every course in the system before anything was
  available to fall back on. The fix fetches only the departments of courses actually in
  the schedule (e.g. just CSCI, MATH) in parallel using the same per-department API the
  browse page uses. Sections now appear immediately on load instead of after a full
  catalog fetch.